### PR TITLE
Twitter URL set incorrectly to the Facebook URL

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -33,7 +33,7 @@
                     {{/if}}
                     <ul class="icons">
                         {{#if @site.twitter}}
-                            <li><a href="{{twitter_url @site.facebook}}" class="icon fa-twitter" title="Twitter"><span class="label">Twitter</span></a></li>
+                            <li><a href="{{twitter_url @site.twitter}}" class="icon fa-twitter" title="Twitter"><span class="label">Twitter</span></a></li>
                         {{/if}}
                         {{#if @site.facebook}}
                             <li><a href="{{facebook_url @site.facebook}}" class="icon fa-facebook" title="Facebook"><span class="label">Facebook</span></a></li>


### PR DESCRIPTION
The anchor tag for the Twitter link in the site header was incorrectly set to `{{twitter_url @site.facebook}}` instead of `{{twitter_url @site.twitter}}`