### PR TITLE
Remove 'Toggle' string in #sidebar

### DIFF
--- a/assets/main/js/main.js
+++ b/assets/main/js/main.js
@@ -89,7 +89,7 @@
 					.appendTo($head);
 
 		// Toggle.
-			$('<a href="#sidebar" class="toggle">Toggle</a>')
+			$('<a href="#sidebar" class="toggle"></a>')
 				.appendTo($sidebar)
 				.on('click', function(event) {
 


### PR DESCRIPTION
I removed **Toggle** in `#sidebar` inner HTML because it will be displayed over the menu icon.

Screenshot:

*Before*:
![Screen Shot 2019-12-05 at 9 09 27 AM](https://user-images.githubusercontent.com/1875666/70197593-f855b880-173e-11ea-9569-952e32ff2b6d.png)

*After*:
![Screen Shot 2019-12-05 at 9 10 42 AM](https://user-images.githubusercontent.com/1875666/70197653-22a77600-173f-11ea-9e8b-1c544e2193b2.png)

