### PR TITLE
Fix author website link

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -20,7 +20,7 @@ into the {body} of the default.hbs template --}}
             {{plural ../pagination.total empty='No posts' singular='% post' plural='% posts'}} <span class="bull">&bull;</span>
         </div>
         {{#if website}}
-        <a href="{{url}}" class="icon fa-globe" title="Website"><span class="label">Website</span></a>
+        <a href="{{website}}" class="icon fa-globe" title="Website"><span class="label">Website</span></a>
         {{/if}}
         {{#if twitter}}
         <a href="{{twitter_url}}" class="icon fa-twitter" title="Twitter"><span class="label">Twitter</span></a>


### PR DESCRIPTION
Currently an author's website link directs the user to the the page they are currently on rather than off-site.