### PR TITLE
Standardized required CI check on the org-wide aggregator gate name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,8 @@ jobs:
 
       - run: pnpm test
 
-  all-tests-pass:
-    name: All tests pass
+  required-checks-pass:
+    name: Required checks pass
     if: always()
     needs: [test]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why

Branch protection on this repo currently requires a status check named exactly `All tests pass`. Requiring a legacy/individual check name couples the ruleset to the CI job matrix: rename the job and the required check silently stops existing, blocking every PR.

The org is standardizing every repo on one stable aggregator check named `Required checks pass` (job id `required-checks-pass`), per the shared required-check convention. This gives branch protection a single stable target regardless of how CI jobs evolve.

## What changes

- Renames the `all-tests-pass` gate job in `.github/workflows/test.yml` to `required-checks-pass` / `Required checks pass`.
- Job shape is unchanged: `if: always()`, `needs: [test]` (same coverage as before - `test` is the only other job in the workflow), single verify step failing on `failure`/`cancelled` results. Top-level `permissions: contents: read` was already present.

## Coordination

The branch ruleset is being updated in the same pass to require `Required checks pass` instead of `All tests pass`, so this PR must go green on the new gate before merge.